### PR TITLE
FE - fix pagination navigation display

### DIFF
--- a/client/components/movieNavigation/MovieNavigation.tsx
+++ b/client/components/movieNavigation/MovieNavigation.tsx
@@ -47,11 +47,11 @@ const MovieNavigation: FunctionComponent<MovieNavigationProps> = ({
     <Container>
       <Row>
         <CustomLink href="#" onClick={onPreviousPage}>
-          <Icon icon={faSquareCaretLeft} />
+          {currentPage > 1 && <Icon icon={faSquareCaretLeft} />}
         </CustomLink>
         <Text color="#ffbf00">{`${currentPage} of ${totalPages}`}</Text>
         <CustomLink href="#" onClick={onNextPage}>
-          <Icon icon={faSquareCaretRight} />
+          {currentPage < totalPages && <Icon icon={faSquareCaretRight} />}
         </CustomLink>
       </Row>
     </Container>

--- a/client/components/movieNavigation/MovieNavigation.tsx
+++ b/client/components/movieNavigation/MovieNavigation.tsx
@@ -47,11 +47,11 @@ const MovieNavigation: FunctionComponent<MovieNavigationProps> = ({
     <Container>
       <Row>
         <CustomLink href="#" onClick={onPreviousPage}>
-          {currentPage > 1 && <Icon icon={faSquareCaretLeft} />}
+          {totalPages !== 1 && <Icon icon={faSquareCaretLeft} />}
         </CustomLink>
         <Text color="#ffbf00">{`${currentPage} of ${totalPages}`}</Text>
         <CustomLink href="#" onClick={onNextPage}>
-          {currentPage < totalPages && <Icon icon={faSquareCaretRight} />}
+          {totalPages !== 1 && <Icon icon={faSquareCaretRight} />}
         </CustomLink>
       </Row>
     </Container>

--- a/client/redux/features/filter/filterSlice.ts
+++ b/client/redux/features/filter/filterSlice.ts
@@ -62,10 +62,18 @@ export const filterSlice = createSlice({
       state.selectedMovie = action.payload;
     },
     nextPage: (state) => {
-      state.totalPages !== state.currentPage && state.currentPage++;
+      if (state.currentPage === state.totalPages) {
+        state.currentPage = 1;
+        return;
+      }
+      state.currentPage++;
     },
     previousPage: (state) => {
-      state.currentPage !== 1 && state.currentPage--;
+      if (state.currentPage === 1 && state.totalPages > 1) {
+        state.currentPage = state.totalPages;
+        return;
+      }
+      state.currentPage--;
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
This PR ensures that 
- hide page navigation button when total pages is 1
- page navigation should be cyclic: 
  - previous page at page 1 navigates to the last page and 
  - next on last page should lead to first.